### PR TITLE
Improve portability of C code

### DIFF
--- a/cbits/cbits.c
+++ b/cbits/cbits.c
@@ -138,4 +138,5 @@ hs_text_short_is_ascii(const uint8_t buf[], const size_t n)
   for (j = 0; j < n; j++)
     if (buf[j] & 0x80)
       return j;
+  return j;
 }


### PR DESCRIPTION
The `hs_text_short_is_ascii` C function is missing a `return` statement for the pure ASCII string case. According to [this post](https://stackoverflow.com/questions/4644860/function-returns-value-without-return-statement) on StackOverflow, the behavior of a missing return statement is undefined and is not portable, although it will work for x86 systems (which most people use).