### PR TITLE
Adding Data (but not Generic) instance

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+  * Add `Data ShortText` instance
+
 ## 0.1.2
 
   * Add `IsList ShortText` and `PrintfArg ShortText` instances

--- a/text-short.cabal
+++ b/text-short.cabal
@@ -1,7 +1,7 @@
 cabal-version:       1.18
 
 name:                text-short
-version:             0.1.2
+version:             0.1.3
 synopsis:            Memory-efficient representation of Unicode text strings
 license:             BSD3
 license-file:        LICENSE


### PR DESCRIPTION
Just adding these instances. Required for consumers of the `text-short` library to derive `Data` & `Generic` instances automatically via `-XDeriveDataTypeable` & `-XDeriveGeneric`, respectively.