### PR TITLE
Check fromString Char for surrogates (fixes #20)

### DIFF
--- a/src/Data/Text/Short/Internal.hs
+++ b/src/Data/Text/Short/Internal.hs
@@ -657,9 +657,10 @@ toText = T.decodeUtf8 . toByteString
 --
 -- @since 0.1
 fromString :: String -> ShortText
-fromString []  = mempty
-fromString [c] = singleton c
-fromString s = ShortText . encodeStringShort utf8 . map r $ s
+fromString s = case s of
+  []  -> mempty
+  [c] -> singleton $ r c
+  _   -> ShortText . encodeStringShort utf8 . map r $ s
   where
     r c | isSurr (ord c) = '\xFFFD'
         | otherwise      = c

--- a/text-short.cabal
+++ b/text-short.cabal
@@ -33,13 +33,13 @@ library
 
   other-modules:       Data.Text.Short.Internal
 
-  build-depends:       base        >= 4.7    && < 4.15
-                     , bytestring  >= 0.10.4 && < 0.11
+  build-depends:       base        >= 4.7    && < 4.16
+                     , bytestring  >= 0.10.4 && < 0.12
                      , hashable    >= 1.2.6  && < 1.4
                      , deepseq     >= 1.3    && < 1.5
                      , text        >= 1.0    && < 1.3
                      , binary      >= 0.7.1  && < 0.9
-                     , ghc-prim    >= 0.3.1  && < 0.7
+                     , ghc-prim    >= 0.3.1  && < 0.8
 
   if !impl(ghc >= 8.0)
      build-depends: semigroups >= 0.18.2 && < 0.20


### PR DESCRIPTION
The singleton case did not transform surrogate characters to replacement characters.  This caused the `fromString` test to fail when using GHC 9.0.1 as described in issue #20.

I tested this fix in GHC 9.0.1 and GHC 8.10.7 and all tests passed.